### PR TITLE
Update Electron to 13.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/wrrnlim/TabViewer#readme",
   "devDependencies": {
-    "electron": "13.5.1",
+    "electron": "13.6.6",
     "electron-builder": "^22.14.5"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes [Dependabot alerts 1](https://github.com/wrrnlim/TabViewer/security/dependabot/1)